### PR TITLE
fix: try to enable json-schema without refs

### DIFF
--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@rfc7946/json-schema": "workspace:*",
     "@rfc7946/typebox": "workspace:*",
     "@rfc7946/zod": "workspace:*",
     "@sinclair/typebox": "^0.32.0",

--- a/packages/benchmarks/src/ajv.ts
+++ b/packages/benchmarks/src/ajv.ts
@@ -1,68 +1,6 @@
-/* import {
-  Altitude,
-  BBox,
-  BBox2D,
-  BBox3D,
-  Feature,
-  FeatureCollection,
-  GeoJSONType,
-  Geometry,
-  GeometryCollectionGeometry,
-  GeometryType,
-  Latitude,
-  LineStringCoordinates,
-  LineStringGeometry,
-  LinearRing,
-  Longitude,
-  MultiLineStringCoordinates,
-  MultiLineStringGeometry,
-  MultiPointCoordinates,
-  MultiPointGeometry,
-  MultiPolygonCoordinates,
-  MultiPolygonGeometry,
-  PointGeometry,
-  PolygonCoordinates,
-  PolygonGeometry,
-  Position,
-  Position2D,
-  Position3D,
-} from "@rfc7946/json-schema";
-import { Type } from "@sinclair/typebox";
+import { FeatureCollection } from "@rfc7946/json-schema";
 import { Ajv } from "ajv";
 
-export const schemas = [
-  Latitude,
-  Longitude,
-  Altitude,
-  Position2D,
-  Position3D,
-  Position,
-  BBox2D,
-  BBox3D,
-  BBox,
-  MultiPointCoordinates,
-  LineStringCoordinates,
-  MultiLineStringCoordinates,
-  LinearRing,
-  PolygonCoordinates,
-  MultiPolygonCoordinates,
-  GeometryType,
-  GeoJSONType,
-  PointGeometry,
-  MultiPointGeometry,
-  LineStringGeometry,
-  MultiLineStringGeometry,
-  PolygonGeometry,
-  MultiPolygonGeometry,
-  GeometryCollectionGeometry,
-  Geometry,
-  Feature,
-];
-
 const ajv = new Ajv();
-for (const schema of schemas) {
-  ajv.addSchema(schema);
-}
 
 export const validate = ajv.compile(FeatureCollection);
- */

--- a/packages/benchmarks/src/index.ts
+++ b/packages/benchmarks/src/index.ts
@@ -6,10 +6,7 @@ import { TypeCompiler } from "@sinclair/typebox/compiler";
 import { Bench } from "tinybench";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { Ajv } from "ajv";
-import { Type } from "@sinclair/typebox";
-// import { validate } from "./ajv.js";
-import { schemas } from "./deref.js";
+import { validate } from "./ajv.js";
 
 const CompiledTypeboxFeatureCollection = TypeCompiler.Compile(
   TypeboxFeatureCollection
@@ -19,10 +16,10 @@ const bench = new Bench({ time: 1000 });
 
 const FIXTURES = await fs.readdir(path.join(import.meta.dirname, "fixtures"));
 const CHECKERS = [
-  // {
-  //   name: "Ajv",
-  //   checker: (data: unknown) => validate(data),
-  // },
+  {
+    name: "Ajv",
+    checker: (data: unknown) => validate(data),
+  },
   {
     name: "Typebox",
     checker: (data: unknown) => Value.Check(TypeboxFeatureCollection, data),

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -72,7 +72,7 @@ const exporters = [
   // makeTypescriptPackage,
   makeTypeboxPackage,
   makeZodPackage,
-  // makeJsonSchemaPackage,
+  makeJsonSchemaPackage,
 ];
 
 for (const exporter of exporters) {

--- a/packages/json-schema/.npmignore
+++ b/packages/json-schema/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+src
+tsconfig.cjs.json
+tsconfig.esm.json

--- a/packages/json-schema/LICENSE.md
+++ b/packages/json-schema/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2024 Kade Robertson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@rfc7946/json-schema",
+  "version": "1.0.0",
+  "author": "Kade Robertson <kade@kaderobertson.dev>",
+  "license": "MIT",
+  "description": "JSON Schema definitions for RFC 7946",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "scripts": {
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:pkg": "echo '{ \"type\": \"module\" }' > dist/esm/package.json",
+    "build": "pnpm build:cjs && pnpm build:esm && pnpm build:pkg"
+  }
+}

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -1,0 +1,4184 @@
+export const Latitude = {
+  $id: "Latitude",
+  minimum: -90,
+  maximum: 90,
+  type: "number",
+};
+export const Longitude = {
+  $id: "Longitude",
+  minimum: -180,
+  maximum: 180,
+  type: "number",
+};
+export const Altitude = {
+  $id: "Altitude",
+  type: "number",
+};
+export const Position2D = {
+  $id: "Position2D",
+  type: "array",
+  items: [
+    {
+      $id: "Longitude",
+      minimum: -180,
+      maximum: 180,
+      type: "number",
+    },
+    {
+      $id: "Latitude",
+      minimum: -90,
+      maximum: 90,
+      type: "number",
+    },
+  ],
+  additionalItems: false,
+  minItems: 2,
+  maxItems: 2,
+};
+export const Position3D = {
+  $id: "Position3D",
+  type: "array",
+  items: [
+    {
+      $id: "Longitude",
+      minimum: -180,
+      maximum: 180,
+      type: "number",
+    },
+    {
+      $id: "Latitude",
+      minimum: -90,
+      maximum: 90,
+      type: "number",
+    },
+    {
+      $id: "Altitude",
+      type: "number",
+    },
+  ],
+  additionalItems: false,
+  minItems: 3,
+  maxItems: 3,
+};
+export const Position = {
+  $id: "Position",
+  anyOf: [
+    {
+      $id: "Position2D",
+      type: "array",
+      items: [
+        {
+          $id: "Longitude",
+          minimum: -180,
+          maximum: 180,
+          type: "number",
+        },
+        {
+          $id: "Latitude",
+          minimum: -90,
+          maximum: 90,
+          type: "number",
+        },
+      ],
+      additionalItems: false,
+      minItems: 2,
+      maxItems: 2,
+    },
+    {
+      $id: "Position3D",
+      type: "array",
+      items: [
+        {
+          $id: "Longitude",
+          minimum: -180,
+          maximum: 180,
+          type: "number",
+        },
+        {
+          $id: "Latitude",
+          minimum: -90,
+          maximum: 90,
+          type: "number",
+        },
+        {
+          $id: "Altitude",
+          type: "number",
+        },
+      ],
+      additionalItems: false,
+      minItems: 3,
+      maxItems: 3,
+    },
+  ],
+};
+export const BBox2D = {
+  $id: "BBox2D",
+  type: "array",
+  items: [
+    {
+      $id: "Longitude",
+      minimum: -180,
+      maximum: 180,
+      type: "number",
+    },
+    {
+      $id: "Latitude",
+      minimum: -90,
+      maximum: 90,
+      type: "number",
+    },
+    {
+      $id: "Longitude",
+      minimum: -180,
+      maximum: 180,
+      type: "number",
+    },
+    {
+      $id: "Latitude",
+      minimum: -90,
+      maximum: 90,
+      type: "number",
+    },
+  ],
+  additionalItems: false,
+  minItems: 4,
+  maxItems: 4,
+};
+export const BBox3D = {
+  $id: "BBox3D",
+  type: "array",
+  items: [
+    {
+      $id: "Longitude",
+      minimum: -180,
+      maximum: 180,
+      type: "number",
+    },
+    {
+      $id: "Latitude",
+      minimum: -90,
+      maximum: 90,
+      type: "number",
+    },
+    {
+      $id: "Altitude",
+      type: "number",
+    },
+    {
+      $id: "Longitude",
+      minimum: -180,
+      maximum: 180,
+      type: "number",
+    },
+    {
+      $id: "Latitude",
+      minimum: -90,
+      maximum: 90,
+      type: "number",
+    },
+    {
+      $id: "Altitude",
+      type: "number",
+    },
+  ],
+  additionalItems: false,
+  minItems: 6,
+  maxItems: 6,
+};
+export const BBox = {
+  $id: "BBox",
+  anyOf: [
+    {
+      $id: "BBox2D",
+      type: "array",
+      items: [
+        {
+          $id: "Longitude",
+          minimum: -180,
+          maximum: 180,
+          type: "number",
+        },
+        {
+          $id: "Latitude",
+          minimum: -90,
+          maximum: 90,
+          type: "number",
+        },
+        {
+          $id: "Longitude",
+          minimum: -180,
+          maximum: 180,
+          type: "number",
+        },
+        {
+          $id: "Latitude",
+          minimum: -90,
+          maximum: 90,
+          type: "number",
+        },
+      ],
+      additionalItems: false,
+      minItems: 4,
+      maxItems: 4,
+    },
+    {
+      $id: "BBox3D",
+      type: "array",
+      items: [
+        {
+          $id: "Longitude",
+          minimum: -180,
+          maximum: 180,
+          type: "number",
+        },
+        {
+          $id: "Latitude",
+          minimum: -90,
+          maximum: 90,
+          type: "number",
+        },
+        {
+          $id: "Altitude",
+          type: "number",
+        },
+        {
+          $id: "Longitude",
+          minimum: -180,
+          maximum: 180,
+          type: "number",
+        },
+        {
+          $id: "Latitude",
+          minimum: -90,
+          maximum: 90,
+          type: "number",
+        },
+        {
+          $id: "Altitude",
+          type: "number",
+        },
+      ],
+      additionalItems: false,
+      minItems: 6,
+      maxItems: 6,
+    },
+  ],
+};
+export const MultiPointCoordinates = {
+  $id: "MultiPointCoordinates",
+  type: "array",
+  items: {
+    $id: "Position",
+    anyOf: [
+      {
+        $id: "Position2D",
+        type: "array",
+        items: [
+          {
+            $id: "Longitude",
+            minimum: -180,
+            maximum: 180,
+            type: "number",
+          },
+          {
+            $id: "Latitude",
+            minimum: -90,
+            maximum: 90,
+            type: "number",
+          },
+        ],
+        additionalItems: false,
+        minItems: 2,
+        maxItems: 2,
+      },
+      {
+        $id: "Position3D",
+        type: "array",
+        items: [
+          {
+            $id: "Longitude",
+            minimum: -180,
+            maximum: 180,
+            type: "number",
+          },
+          {
+            $id: "Latitude",
+            minimum: -90,
+            maximum: 90,
+            type: "number",
+          },
+          {
+            $id: "Altitude",
+            type: "number",
+          },
+        ],
+        additionalItems: false,
+        minItems: 3,
+        maxItems: 3,
+      },
+    ],
+  },
+};
+export const LineStringCoordinates = {
+  minItems: 2,
+  $id: "LineStringCoordinates",
+  type: "array",
+  items: {
+    $id: "Position",
+    anyOf: [
+      {
+        $id: "Position2D",
+        type: "array",
+        items: [
+          {
+            $id: "Longitude",
+            minimum: -180,
+            maximum: 180,
+            type: "number",
+          },
+          {
+            $id: "Latitude",
+            minimum: -90,
+            maximum: 90,
+            type: "number",
+          },
+        ],
+        additionalItems: false,
+        minItems: 2,
+        maxItems: 2,
+      },
+      {
+        $id: "Position3D",
+        type: "array",
+        items: [
+          {
+            $id: "Longitude",
+            minimum: -180,
+            maximum: 180,
+            type: "number",
+          },
+          {
+            $id: "Latitude",
+            minimum: -90,
+            maximum: 90,
+            type: "number",
+          },
+          {
+            $id: "Altitude",
+            type: "number",
+          },
+        ],
+        additionalItems: false,
+        minItems: 3,
+        maxItems: 3,
+      },
+    ],
+  },
+};
+export const MultiLineStringCoordinates = {
+  $id: "MultiLineStringCoordinates",
+  type: "array",
+  items: {
+    minItems: 2,
+    $id: "LineStringCoordinates",
+    type: "array",
+    items: {
+      $id: "Position",
+      anyOf: [
+        {
+          $id: "Position2D",
+          type: "array",
+          items: [
+            {
+              $id: "Longitude",
+              minimum: -180,
+              maximum: 180,
+              type: "number",
+            },
+            {
+              $id: "Latitude",
+              minimum: -90,
+              maximum: 90,
+              type: "number",
+            },
+          ],
+          additionalItems: false,
+          minItems: 2,
+          maxItems: 2,
+        },
+        {
+          $id: "Position3D",
+          type: "array",
+          items: [
+            {
+              $id: "Longitude",
+              minimum: -180,
+              maximum: 180,
+              type: "number",
+            },
+            {
+              $id: "Latitude",
+              minimum: -90,
+              maximum: 90,
+              type: "number",
+            },
+            {
+              $id: "Altitude",
+              type: "number",
+            },
+          ],
+          additionalItems: false,
+          minItems: 3,
+          maxItems: 3,
+        },
+      ],
+    },
+  },
+};
+export const LinearRing = {
+  minItems: 4,
+  $id: "LinearRing",
+  type: "array",
+  items: {
+    $id: "Position",
+    anyOf: [
+      {
+        $id: "Position2D",
+        type: "array",
+        items: [
+          {
+            $id: "Longitude",
+            minimum: -180,
+            maximum: 180,
+            type: "number",
+          },
+          {
+            $id: "Latitude",
+            minimum: -90,
+            maximum: 90,
+            type: "number",
+          },
+        ],
+        additionalItems: false,
+        minItems: 2,
+        maxItems: 2,
+      },
+      {
+        $id: "Position3D",
+        type: "array",
+        items: [
+          {
+            $id: "Longitude",
+            minimum: -180,
+            maximum: 180,
+            type: "number",
+          },
+          {
+            $id: "Latitude",
+            minimum: -90,
+            maximum: 90,
+            type: "number",
+          },
+          {
+            $id: "Altitude",
+            type: "number",
+          },
+        ],
+        additionalItems: false,
+        minItems: 3,
+        maxItems: 3,
+      },
+    ],
+  },
+};
+export const PolygonCoordinates = {
+  $id: "PolygonCoordinates",
+  type: "array",
+  items: {
+    minItems: 4,
+    $id: "LinearRing",
+    type: "array",
+    items: {
+      $id: "Position",
+      anyOf: [
+        {
+          $id: "Position2D",
+          type: "array",
+          items: [
+            {
+              $id: "Longitude",
+              minimum: -180,
+              maximum: 180,
+              type: "number",
+            },
+            {
+              $id: "Latitude",
+              minimum: -90,
+              maximum: 90,
+              type: "number",
+            },
+          ],
+          additionalItems: false,
+          minItems: 2,
+          maxItems: 2,
+        },
+        {
+          $id: "Position3D",
+          type: "array",
+          items: [
+            {
+              $id: "Longitude",
+              minimum: -180,
+              maximum: 180,
+              type: "number",
+            },
+            {
+              $id: "Latitude",
+              minimum: -90,
+              maximum: 90,
+              type: "number",
+            },
+            {
+              $id: "Altitude",
+              type: "number",
+            },
+          ],
+          additionalItems: false,
+          minItems: 3,
+          maxItems: 3,
+        },
+      ],
+    },
+  },
+};
+export const MultiPolygonCoordinates = {
+  $id: "MultiPolygonCoordinates",
+  type: "array",
+  items: {
+    $id: "PolygonCoordinates",
+    type: "array",
+    items: {
+      minItems: 4,
+      $id: "LinearRing",
+      type: "array",
+      items: {
+        $id: "Position",
+        anyOf: [
+          {
+            $id: "Position2D",
+            type: "array",
+            items: [
+              {
+                $id: "Longitude",
+                minimum: -180,
+                maximum: 180,
+                type: "number",
+              },
+              {
+                $id: "Latitude",
+                minimum: -90,
+                maximum: 90,
+                type: "number",
+              },
+            ],
+            additionalItems: false,
+            minItems: 2,
+            maxItems: 2,
+          },
+          {
+            $id: "Position3D",
+            type: "array",
+            items: [
+              {
+                $id: "Longitude",
+                minimum: -180,
+                maximum: 180,
+                type: "number",
+              },
+              {
+                $id: "Latitude",
+                minimum: -90,
+                maximum: 90,
+                type: "number",
+              },
+              {
+                $id: "Altitude",
+                type: "number",
+              },
+            ],
+            additionalItems: false,
+            minItems: 3,
+            maxItems: 3,
+          },
+        ],
+      },
+    },
+  },
+};
+export const GeometryType = {
+  $id: "GeometryType",
+  anyOf: [
+    {
+      const: "Point",
+      type: "string",
+    },
+    {
+      const: "MultiPoint",
+      type: "string",
+    },
+    {
+      const: "LineString",
+      type: "string",
+    },
+    {
+      const: "MultiLineString",
+      type: "string",
+    },
+    {
+      const: "Polygon",
+      type: "string",
+    },
+    {
+      const: "MultiPolygon",
+      type: "string",
+    },
+    {
+      const: "GeometryCollection",
+      type: "string",
+    },
+  ],
+};
+export const GeoJSONType = {
+  $id: "GeoJSONType",
+  anyOf: [
+    {
+      const: "Point",
+      type: "string",
+    },
+    {
+      const: "MultiPoint",
+      type: "string",
+    },
+    {
+      const: "LineString",
+      type: "string",
+    },
+    {
+      const: "MultiLineString",
+      type: "string",
+    },
+    {
+      const: "Polygon",
+      type: "string",
+    },
+    {
+      const: "MultiPolygon",
+      type: "string",
+    },
+    {
+      const: "GeometryCollection",
+      type: "string",
+    },
+    {
+      const: "Feature",
+      type: "string",
+    },
+    {
+      const: "FeatureCollection",
+      type: "string",
+    },
+  ],
+};
+export const PointGeometry = {
+  $id: "PointGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "Point",
+      type: "string",
+    },
+    coordinates: {
+      $id: "Position",
+      anyOf: [
+        {
+          $id: "Position2D",
+          type: "array",
+          items: [
+            {
+              $id: "Longitude",
+              minimum: -180,
+              maximum: 180,
+              type: "number",
+            },
+            {
+              $id: "Latitude",
+              minimum: -90,
+              maximum: 90,
+              type: "number",
+            },
+          ],
+          additionalItems: false,
+          minItems: 2,
+          maxItems: 2,
+        },
+        {
+          $id: "Position3D",
+          type: "array",
+          items: [
+            {
+              $id: "Longitude",
+              minimum: -180,
+              maximum: 180,
+              type: "number",
+            },
+            {
+              $id: "Latitude",
+              minimum: -90,
+              maximum: 90,
+              type: "number",
+            },
+            {
+              $id: "Altitude",
+              type: "number",
+            },
+          ],
+          additionalItems: false,
+          minItems: 3,
+          maxItems: 3,
+        },
+      ],
+    },
+  },
+  required: ["type", "coordinates"],
+};
+export const MultiPointGeometry = {
+  $id: "MultiPointGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "MultiPoint",
+      type: "string",
+    },
+    coordinates: {
+      $id: "MultiPointCoordinates",
+      type: "array",
+      items: {
+        $id: "Position",
+        anyOf: [
+          {
+            $id: "Position2D",
+            type: "array",
+            items: [
+              {
+                $id: "Longitude",
+                minimum: -180,
+                maximum: 180,
+                type: "number",
+              },
+              {
+                $id: "Latitude",
+                minimum: -90,
+                maximum: 90,
+                type: "number",
+              },
+            ],
+            additionalItems: false,
+            minItems: 2,
+            maxItems: 2,
+          },
+          {
+            $id: "Position3D",
+            type: "array",
+            items: [
+              {
+                $id: "Longitude",
+                minimum: -180,
+                maximum: 180,
+                type: "number",
+              },
+              {
+                $id: "Latitude",
+                minimum: -90,
+                maximum: 90,
+                type: "number",
+              },
+              {
+                $id: "Altitude",
+                type: "number",
+              },
+            ],
+            additionalItems: false,
+            minItems: 3,
+            maxItems: 3,
+          },
+        ],
+      },
+    },
+  },
+  required: ["type", "coordinates"],
+};
+export const LineStringGeometry = {
+  $id: "LineStringGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "LineString",
+      type: "string",
+    },
+    coordinates: {
+      minItems: 2,
+      $id: "LineStringCoordinates",
+      type: "array",
+      items: {
+        $id: "Position",
+        anyOf: [
+          {
+            $id: "Position2D",
+            type: "array",
+            items: [
+              {
+                $id: "Longitude",
+                minimum: -180,
+                maximum: 180,
+                type: "number",
+              },
+              {
+                $id: "Latitude",
+                minimum: -90,
+                maximum: 90,
+                type: "number",
+              },
+            ],
+            additionalItems: false,
+            minItems: 2,
+            maxItems: 2,
+          },
+          {
+            $id: "Position3D",
+            type: "array",
+            items: [
+              {
+                $id: "Longitude",
+                minimum: -180,
+                maximum: 180,
+                type: "number",
+              },
+              {
+                $id: "Latitude",
+                minimum: -90,
+                maximum: 90,
+                type: "number",
+              },
+              {
+                $id: "Altitude",
+                type: "number",
+              },
+            ],
+            additionalItems: false,
+            minItems: 3,
+            maxItems: 3,
+          },
+        ],
+      },
+    },
+  },
+  required: ["type", "coordinates"],
+};
+export const MultiLineStringGeometry = {
+  $id: "MultiLineStringGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "MultiLineString",
+      type: "string",
+    },
+    coordinates: {
+      $id: "MultiLineStringCoordinates",
+      type: "array",
+      items: {
+        minItems: 2,
+        $id: "LineStringCoordinates",
+        type: "array",
+        items: {
+          $id: "Position",
+          anyOf: [
+            {
+              $id: "Position2D",
+              type: "array",
+              items: [
+                {
+                  $id: "Longitude",
+                  minimum: -180,
+                  maximum: 180,
+                  type: "number",
+                },
+                {
+                  $id: "Latitude",
+                  minimum: -90,
+                  maximum: 90,
+                  type: "number",
+                },
+              ],
+              additionalItems: false,
+              minItems: 2,
+              maxItems: 2,
+            },
+            {
+              $id: "Position3D",
+              type: "array",
+              items: [
+                {
+                  $id: "Longitude",
+                  minimum: -180,
+                  maximum: 180,
+                  type: "number",
+                },
+                {
+                  $id: "Latitude",
+                  minimum: -90,
+                  maximum: 90,
+                  type: "number",
+                },
+                {
+                  $id: "Altitude",
+                  type: "number",
+                },
+              ],
+              additionalItems: false,
+              minItems: 3,
+              maxItems: 3,
+            },
+          ],
+        },
+      },
+    },
+  },
+  required: ["type", "coordinates"],
+};
+export const PolygonGeometry = {
+  $id: "PolygonGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "Polygon",
+      type: "string",
+    },
+    coordinates: {
+      $id: "PolygonCoordinates",
+      type: "array",
+      items: {
+        minItems: 4,
+        $id: "LinearRing",
+        type: "array",
+        items: {
+          $id: "Position",
+          anyOf: [
+            {
+              $id: "Position2D",
+              type: "array",
+              items: [
+                {
+                  $id: "Longitude",
+                  minimum: -180,
+                  maximum: 180,
+                  type: "number",
+                },
+                {
+                  $id: "Latitude",
+                  minimum: -90,
+                  maximum: 90,
+                  type: "number",
+                },
+              ],
+              additionalItems: false,
+              minItems: 2,
+              maxItems: 2,
+            },
+            {
+              $id: "Position3D",
+              type: "array",
+              items: [
+                {
+                  $id: "Longitude",
+                  minimum: -180,
+                  maximum: 180,
+                  type: "number",
+                },
+                {
+                  $id: "Latitude",
+                  minimum: -90,
+                  maximum: 90,
+                  type: "number",
+                },
+                {
+                  $id: "Altitude",
+                  type: "number",
+                },
+              ],
+              additionalItems: false,
+              minItems: 3,
+              maxItems: 3,
+            },
+          ],
+        },
+      },
+    },
+  },
+  required: ["type", "coordinates"],
+};
+export const MultiPolygonGeometry = {
+  $id: "MultiPolygonGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "MultiPolygon",
+      type: "string",
+    },
+    coordinates: {
+      $id: "MultiPolygonCoordinates",
+      type: "array",
+      items: {
+        $id: "PolygonCoordinates",
+        type: "array",
+        items: {
+          minItems: 4,
+          $id: "LinearRing",
+          type: "array",
+          items: {
+            $id: "Position",
+            anyOf: [
+              {
+                $id: "Position2D",
+                type: "array",
+                items: [
+                  {
+                    $id: "Longitude",
+                    minimum: -180,
+                    maximum: 180,
+                    type: "number",
+                  },
+                  {
+                    $id: "Latitude",
+                    minimum: -90,
+                    maximum: 90,
+                    type: "number",
+                  },
+                ],
+                additionalItems: false,
+                minItems: 2,
+                maxItems: 2,
+              },
+              {
+                $id: "Position3D",
+                type: "array",
+                items: [
+                  {
+                    $id: "Longitude",
+                    minimum: -180,
+                    maximum: 180,
+                    type: "number",
+                  },
+                  {
+                    $id: "Latitude",
+                    minimum: -90,
+                    maximum: 90,
+                    type: "number",
+                  },
+                  {
+                    $id: "Altitude",
+                    type: "number",
+                  },
+                ],
+                additionalItems: false,
+                minItems: 3,
+                maxItems: 3,
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  required: ["type", "coordinates"],
+};
+export const GeometryCollectionGeometry = {
+  $id: "GeometryCollectionGeometry",
+  type: "object",
+  properties: {
+    type: {
+      const: "GeometryCollection",
+      type: "string",
+    },
+    geometries: {
+      type: "array",
+      items: {
+        anyOf: [
+          {
+            $ref: "GeometryCollectionGeometry",
+          },
+          {
+            $id: "PointGeometry",
+            type: "object",
+            properties: {
+              type: {
+                const: "Point",
+                type: "string",
+              },
+              coordinates: {
+                $id: "Position",
+                anyOf: [
+                  {
+                    $id: "Position2D",
+                    type: "array",
+                    items: [
+                      {
+                        $id: "Longitude",
+                        minimum: -180,
+                        maximum: 180,
+                        type: "number",
+                      },
+                      {
+                        $id: "Latitude",
+                        minimum: -90,
+                        maximum: 90,
+                        type: "number",
+                      },
+                    ],
+                    additionalItems: false,
+                    minItems: 2,
+                    maxItems: 2,
+                  },
+                  {
+                    $id: "Position3D",
+                    type: "array",
+                    items: [
+                      {
+                        $id: "Longitude",
+                        minimum: -180,
+                        maximum: 180,
+                        type: "number",
+                      },
+                      {
+                        $id: "Latitude",
+                        minimum: -90,
+                        maximum: 90,
+                        type: "number",
+                      },
+                      {
+                        $id: "Altitude",
+                        type: "number",
+                      },
+                    ],
+                    additionalItems: false,
+                    minItems: 3,
+                    maxItems: 3,
+                  },
+                ],
+              },
+            },
+            required: ["type", "coordinates"],
+          },
+          {
+            $id: "MultiPointGeometry",
+            type: "object",
+            properties: {
+              type: {
+                const: "MultiPoint",
+                type: "string",
+              },
+              coordinates: {
+                $id: "MultiPointCoordinates",
+                type: "array",
+                items: {
+                  $id: "Position",
+                  anyOf: [
+                    {
+                      $id: "Position2D",
+                      type: "array",
+                      items: [
+                        {
+                          $id: "Longitude",
+                          minimum: -180,
+                          maximum: 180,
+                          type: "number",
+                        },
+                        {
+                          $id: "Latitude",
+                          minimum: -90,
+                          maximum: 90,
+                          type: "number",
+                        },
+                      ],
+                      additionalItems: false,
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                    {
+                      $id: "Position3D",
+                      type: "array",
+                      items: [
+                        {
+                          $id: "Longitude",
+                          minimum: -180,
+                          maximum: 180,
+                          type: "number",
+                        },
+                        {
+                          $id: "Latitude",
+                          minimum: -90,
+                          maximum: 90,
+                          type: "number",
+                        },
+                        {
+                          $id: "Altitude",
+                          type: "number",
+                        },
+                      ],
+                      additionalItems: false,
+                      minItems: 3,
+                      maxItems: 3,
+                    },
+                  ],
+                },
+              },
+            },
+            required: ["type", "coordinates"],
+          },
+          {
+            $id: "LineStringGeometry",
+            type: "object",
+            properties: {
+              type: {
+                const: "LineString",
+                type: "string",
+              },
+              coordinates: {
+                minItems: 2,
+                $id: "LineStringCoordinates",
+                type: "array",
+                items: {
+                  $id: "Position",
+                  anyOf: [
+                    {
+                      $id: "Position2D",
+                      type: "array",
+                      items: [
+                        {
+                          $id: "Longitude",
+                          minimum: -180,
+                          maximum: 180,
+                          type: "number",
+                        },
+                        {
+                          $id: "Latitude",
+                          minimum: -90,
+                          maximum: 90,
+                          type: "number",
+                        },
+                      ],
+                      additionalItems: false,
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                    {
+                      $id: "Position3D",
+                      type: "array",
+                      items: [
+                        {
+                          $id: "Longitude",
+                          minimum: -180,
+                          maximum: 180,
+                          type: "number",
+                        },
+                        {
+                          $id: "Latitude",
+                          minimum: -90,
+                          maximum: 90,
+                          type: "number",
+                        },
+                        {
+                          $id: "Altitude",
+                          type: "number",
+                        },
+                      ],
+                      additionalItems: false,
+                      minItems: 3,
+                      maxItems: 3,
+                    },
+                  ],
+                },
+              },
+            },
+            required: ["type", "coordinates"],
+          },
+          {
+            $id: "MultiLineStringGeometry",
+            type: "object",
+            properties: {
+              type: {
+                const: "MultiLineString",
+                type: "string",
+              },
+              coordinates: {
+                $id: "MultiLineStringCoordinates",
+                type: "array",
+                items: {
+                  minItems: 2,
+                  $id: "LineStringCoordinates",
+                  type: "array",
+                  items: {
+                    $id: "Position",
+                    anyOf: [
+                      {
+                        $id: "Position2D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 2,
+                        maxItems: 2,
+                      },
+                      {
+                        $id: "Position3D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                          {
+                            $id: "Altitude",
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 3,
+                        maxItems: 3,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+            required: ["type", "coordinates"],
+          },
+          {
+            $id: "PolygonGeometry",
+            type: "object",
+            properties: {
+              type: {
+                const: "Polygon",
+                type: "string",
+              },
+              coordinates: {
+                $id: "PolygonCoordinates",
+                type: "array",
+                items: {
+                  minItems: 4,
+                  $id: "LinearRing",
+                  type: "array",
+                  items: {
+                    $id: "Position",
+                    anyOf: [
+                      {
+                        $id: "Position2D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 2,
+                        maxItems: 2,
+                      },
+                      {
+                        $id: "Position3D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                          {
+                            $id: "Altitude",
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 3,
+                        maxItems: 3,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+            required: ["type", "coordinates"],
+          },
+          {
+            $id: "MultiPolygonGeometry",
+            type: "object",
+            properties: {
+              type: {
+                const: "MultiPolygon",
+                type: "string",
+              },
+              coordinates: {
+                $id: "MultiPolygonCoordinates",
+                type: "array",
+                items: {
+                  $id: "PolygonCoordinates",
+                  type: "array",
+                  items: {
+                    minItems: 4,
+                    $id: "LinearRing",
+                    type: "array",
+                    items: {
+                      $id: "Position",
+                      anyOf: [
+                        {
+                          $id: "Position2D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 2,
+                          maxItems: 2,
+                        },
+                        {
+                          $id: "Position3D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                            {
+                              $id: "Altitude",
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 3,
+                          maxItems: 3,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+            required: ["type", "coordinates"],
+          },
+        ],
+      },
+    },
+  },
+  required: ["type", "geometries"],
+};
+export const Geometry = {
+  $id: "Geometry",
+  anyOf: [
+    {
+      $id: "PointGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "Point",
+          type: "string",
+        },
+        coordinates: {
+          $id: "Position",
+          anyOf: [
+            {
+              $id: "Position2D",
+              type: "array",
+              items: [
+                {
+                  $id: "Longitude",
+                  minimum: -180,
+                  maximum: 180,
+                  type: "number",
+                },
+                {
+                  $id: "Latitude",
+                  minimum: -90,
+                  maximum: 90,
+                  type: "number",
+                },
+              ],
+              additionalItems: false,
+              minItems: 2,
+              maxItems: 2,
+            },
+            {
+              $id: "Position3D",
+              type: "array",
+              items: [
+                {
+                  $id: "Longitude",
+                  minimum: -180,
+                  maximum: 180,
+                  type: "number",
+                },
+                {
+                  $id: "Latitude",
+                  minimum: -90,
+                  maximum: 90,
+                  type: "number",
+                },
+                {
+                  $id: "Altitude",
+                  type: "number",
+                },
+              ],
+              additionalItems: false,
+              minItems: 3,
+              maxItems: 3,
+            },
+          ],
+        },
+      },
+      required: ["type", "coordinates"],
+    },
+    {
+      $id: "MultiPointGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "MultiPoint",
+          type: "string",
+        },
+        coordinates: {
+          $id: "MultiPointCoordinates",
+          type: "array",
+          items: {
+            $id: "Position",
+            anyOf: [
+              {
+                $id: "Position2D",
+                type: "array",
+                items: [
+                  {
+                    $id: "Longitude",
+                    minimum: -180,
+                    maximum: 180,
+                    type: "number",
+                  },
+                  {
+                    $id: "Latitude",
+                    minimum: -90,
+                    maximum: 90,
+                    type: "number",
+                  },
+                ],
+                additionalItems: false,
+                minItems: 2,
+                maxItems: 2,
+              },
+              {
+                $id: "Position3D",
+                type: "array",
+                items: [
+                  {
+                    $id: "Longitude",
+                    minimum: -180,
+                    maximum: 180,
+                    type: "number",
+                  },
+                  {
+                    $id: "Latitude",
+                    minimum: -90,
+                    maximum: 90,
+                    type: "number",
+                  },
+                  {
+                    $id: "Altitude",
+                    type: "number",
+                  },
+                ],
+                additionalItems: false,
+                minItems: 3,
+                maxItems: 3,
+              },
+            ],
+          },
+        },
+      },
+      required: ["type", "coordinates"],
+    },
+    {
+      $id: "LineStringGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "LineString",
+          type: "string",
+        },
+        coordinates: {
+          minItems: 2,
+          $id: "LineStringCoordinates",
+          type: "array",
+          items: {
+            $id: "Position",
+            anyOf: [
+              {
+                $id: "Position2D",
+                type: "array",
+                items: [
+                  {
+                    $id: "Longitude",
+                    minimum: -180,
+                    maximum: 180,
+                    type: "number",
+                  },
+                  {
+                    $id: "Latitude",
+                    minimum: -90,
+                    maximum: 90,
+                    type: "number",
+                  },
+                ],
+                additionalItems: false,
+                minItems: 2,
+                maxItems: 2,
+              },
+              {
+                $id: "Position3D",
+                type: "array",
+                items: [
+                  {
+                    $id: "Longitude",
+                    minimum: -180,
+                    maximum: 180,
+                    type: "number",
+                  },
+                  {
+                    $id: "Latitude",
+                    minimum: -90,
+                    maximum: 90,
+                    type: "number",
+                  },
+                  {
+                    $id: "Altitude",
+                    type: "number",
+                  },
+                ],
+                additionalItems: false,
+                minItems: 3,
+                maxItems: 3,
+              },
+            ],
+          },
+        },
+      },
+      required: ["type", "coordinates"],
+    },
+    {
+      $id: "MultiLineStringGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "MultiLineString",
+          type: "string",
+        },
+        coordinates: {
+          $id: "MultiLineStringCoordinates",
+          type: "array",
+          items: {
+            minItems: 2,
+            $id: "LineStringCoordinates",
+            type: "array",
+            items: {
+              $id: "Position",
+              anyOf: [
+                {
+                  $id: "Position2D",
+                  type: "array",
+                  items: [
+                    {
+                      $id: "Longitude",
+                      minimum: -180,
+                      maximum: 180,
+                      type: "number",
+                    },
+                    {
+                      $id: "Latitude",
+                      minimum: -90,
+                      maximum: 90,
+                      type: "number",
+                    },
+                  ],
+                  additionalItems: false,
+                  minItems: 2,
+                  maxItems: 2,
+                },
+                {
+                  $id: "Position3D",
+                  type: "array",
+                  items: [
+                    {
+                      $id: "Longitude",
+                      minimum: -180,
+                      maximum: 180,
+                      type: "number",
+                    },
+                    {
+                      $id: "Latitude",
+                      minimum: -90,
+                      maximum: 90,
+                      type: "number",
+                    },
+                    {
+                      $id: "Altitude",
+                      type: "number",
+                    },
+                  ],
+                  additionalItems: false,
+                  minItems: 3,
+                  maxItems: 3,
+                },
+              ],
+            },
+          },
+        },
+      },
+      required: ["type", "coordinates"],
+    },
+    {
+      $id: "PolygonGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "Polygon",
+          type: "string",
+        },
+        coordinates: {
+          $id: "PolygonCoordinates",
+          type: "array",
+          items: {
+            minItems: 4,
+            $id: "LinearRing",
+            type: "array",
+            items: {
+              $id: "Position",
+              anyOf: [
+                {
+                  $id: "Position2D",
+                  type: "array",
+                  items: [
+                    {
+                      $id: "Longitude",
+                      minimum: -180,
+                      maximum: 180,
+                      type: "number",
+                    },
+                    {
+                      $id: "Latitude",
+                      minimum: -90,
+                      maximum: 90,
+                      type: "number",
+                    },
+                  ],
+                  additionalItems: false,
+                  minItems: 2,
+                  maxItems: 2,
+                },
+                {
+                  $id: "Position3D",
+                  type: "array",
+                  items: [
+                    {
+                      $id: "Longitude",
+                      minimum: -180,
+                      maximum: 180,
+                      type: "number",
+                    },
+                    {
+                      $id: "Latitude",
+                      minimum: -90,
+                      maximum: 90,
+                      type: "number",
+                    },
+                    {
+                      $id: "Altitude",
+                      type: "number",
+                    },
+                  ],
+                  additionalItems: false,
+                  minItems: 3,
+                  maxItems: 3,
+                },
+              ],
+            },
+          },
+        },
+      },
+      required: ["type", "coordinates"],
+    },
+    {
+      $id: "MultiPolygonGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "MultiPolygon",
+          type: "string",
+        },
+        coordinates: {
+          $id: "MultiPolygonCoordinates",
+          type: "array",
+          items: {
+            $id: "PolygonCoordinates",
+            type: "array",
+            items: {
+              minItems: 4,
+              $id: "LinearRing",
+              type: "array",
+              items: {
+                $id: "Position",
+                anyOf: [
+                  {
+                    $id: "Position2D",
+                    type: "array",
+                    items: [
+                      {
+                        $id: "Longitude",
+                        minimum: -180,
+                        maximum: 180,
+                        type: "number",
+                      },
+                      {
+                        $id: "Latitude",
+                        minimum: -90,
+                        maximum: 90,
+                        type: "number",
+                      },
+                    ],
+                    additionalItems: false,
+                    minItems: 2,
+                    maxItems: 2,
+                  },
+                  {
+                    $id: "Position3D",
+                    type: "array",
+                    items: [
+                      {
+                        $id: "Longitude",
+                        minimum: -180,
+                        maximum: 180,
+                        type: "number",
+                      },
+                      {
+                        $id: "Latitude",
+                        minimum: -90,
+                        maximum: 90,
+                        type: "number",
+                      },
+                      {
+                        $id: "Altitude",
+                        type: "number",
+                      },
+                    ],
+                    additionalItems: false,
+                    minItems: 3,
+                    maxItems: 3,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      required: ["type", "coordinates"],
+    },
+    {
+      $id: "GeometryCollectionGeometry",
+      type: "object",
+      properties: {
+        type: {
+          const: "GeometryCollection",
+          type: "string",
+        },
+        geometries: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                $ref: "GeometryCollectionGeometry",
+              },
+              {
+                $id: "PointGeometry",
+                type: "object",
+                properties: {
+                  type: {
+                    const: "Point",
+                    type: "string",
+                  },
+                  coordinates: {
+                    $id: "Position",
+                    anyOf: [
+                      {
+                        $id: "Position2D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 2,
+                        maxItems: 2,
+                      },
+                      {
+                        $id: "Position3D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                          {
+                            $id: "Altitude",
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 3,
+                        maxItems: 3,
+                      },
+                    ],
+                  },
+                },
+                required: ["type", "coordinates"],
+              },
+              {
+                $id: "MultiPointGeometry",
+                type: "object",
+                properties: {
+                  type: {
+                    const: "MultiPoint",
+                    type: "string",
+                  },
+                  coordinates: {
+                    $id: "MultiPointCoordinates",
+                    type: "array",
+                    items: {
+                      $id: "Position",
+                      anyOf: [
+                        {
+                          $id: "Position2D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 2,
+                          maxItems: 2,
+                        },
+                        {
+                          $id: "Position3D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                            {
+                              $id: "Altitude",
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 3,
+                          maxItems: 3,
+                        },
+                      ],
+                    },
+                  },
+                },
+                required: ["type", "coordinates"],
+              },
+              {
+                $id: "LineStringGeometry",
+                type: "object",
+                properties: {
+                  type: {
+                    const: "LineString",
+                    type: "string",
+                  },
+                  coordinates: {
+                    minItems: 2,
+                    $id: "LineStringCoordinates",
+                    type: "array",
+                    items: {
+                      $id: "Position",
+                      anyOf: [
+                        {
+                          $id: "Position2D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 2,
+                          maxItems: 2,
+                        },
+                        {
+                          $id: "Position3D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                            {
+                              $id: "Altitude",
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 3,
+                          maxItems: 3,
+                        },
+                      ],
+                    },
+                  },
+                },
+                required: ["type", "coordinates"],
+              },
+              {
+                $id: "MultiLineStringGeometry",
+                type: "object",
+                properties: {
+                  type: {
+                    const: "MultiLineString",
+                    type: "string",
+                  },
+                  coordinates: {
+                    $id: "MultiLineStringCoordinates",
+                    type: "array",
+                    items: {
+                      minItems: 2,
+                      $id: "LineStringCoordinates",
+                      type: "array",
+                      items: {
+                        $id: "Position",
+                        anyOf: [
+                          {
+                            $id: "Position2D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 2,
+                            maxItems: 2,
+                          },
+                          {
+                            $id: "Position3D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                              {
+                                $id: "Altitude",
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 3,
+                            maxItems: 3,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+                required: ["type", "coordinates"],
+              },
+              {
+                $id: "PolygonGeometry",
+                type: "object",
+                properties: {
+                  type: {
+                    const: "Polygon",
+                    type: "string",
+                  },
+                  coordinates: {
+                    $id: "PolygonCoordinates",
+                    type: "array",
+                    items: {
+                      minItems: 4,
+                      $id: "LinearRing",
+                      type: "array",
+                      items: {
+                        $id: "Position",
+                        anyOf: [
+                          {
+                            $id: "Position2D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 2,
+                            maxItems: 2,
+                          },
+                          {
+                            $id: "Position3D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                              {
+                                $id: "Altitude",
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 3,
+                            maxItems: 3,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+                required: ["type", "coordinates"],
+              },
+              {
+                $id: "MultiPolygonGeometry",
+                type: "object",
+                properties: {
+                  type: {
+                    const: "MultiPolygon",
+                    type: "string",
+                  },
+                  coordinates: {
+                    $id: "MultiPolygonCoordinates",
+                    type: "array",
+                    items: {
+                      $id: "PolygonCoordinates",
+                      type: "array",
+                      items: {
+                        minItems: 4,
+                        $id: "LinearRing",
+                        type: "array",
+                        items: {
+                          $id: "Position",
+                          anyOf: [
+                            {
+                              $id: "Position2D",
+                              type: "array",
+                              items: [
+                                {
+                                  $id: "Longitude",
+                                  minimum: -180,
+                                  maximum: 180,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Latitude",
+                                  minimum: -90,
+                                  maximum: 90,
+                                  type: "number",
+                                },
+                              ],
+                              additionalItems: false,
+                              minItems: 2,
+                              maxItems: 2,
+                            },
+                            {
+                              $id: "Position3D",
+                              type: "array",
+                              items: [
+                                {
+                                  $id: "Longitude",
+                                  minimum: -180,
+                                  maximum: 180,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Latitude",
+                                  minimum: -90,
+                                  maximum: 90,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Altitude",
+                                  type: "number",
+                                },
+                              ],
+                              additionalItems: false,
+                              minItems: 3,
+                              maxItems: 3,
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+                required: ["type", "coordinates"],
+              },
+            ],
+          },
+        },
+      },
+      required: ["type", "geometries"],
+    },
+  ],
+};
+export const Feature = {
+  $id: "Feature",
+  type: "object",
+  properties: {
+    id: {
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "number",
+        },
+      ],
+    },
+    type: {
+      const: "Feature",
+      type: "string",
+    },
+    geometry: {
+      anyOf: [
+        {
+          $id: "Geometry",
+          anyOf: [
+            {
+              $id: "PointGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "Point",
+                  type: "string",
+                },
+                coordinates: {
+                  $id: "Position",
+                  anyOf: [
+                    {
+                      $id: "Position2D",
+                      type: "array",
+                      items: [
+                        {
+                          $id: "Longitude",
+                          minimum: -180,
+                          maximum: 180,
+                          type: "number",
+                        },
+                        {
+                          $id: "Latitude",
+                          minimum: -90,
+                          maximum: 90,
+                          type: "number",
+                        },
+                      ],
+                      additionalItems: false,
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                    {
+                      $id: "Position3D",
+                      type: "array",
+                      items: [
+                        {
+                          $id: "Longitude",
+                          minimum: -180,
+                          maximum: 180,
+                          type: "number",
+                        },
+                        {
+                          $id: "Latitude",
+                          minimum: -90,
+                          maximum: 90,
+                          type: "number",
+                        },
+                        {
+                          $id: "Altitude",
+                          type: "number",
+                        },
+                      ],
+                      additionalItems: false,
+                      minItems: 3,
+                      maxItems: 3,
+                    },
+                  ],
+                },
+              },
+              required: ["type", "coordinates"],
+            },
+            {
+              $id: "MultiPointGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "MultiPoint",
+                  type: "string",
+                },
+                coordinates: {
+                  $id: "MultiPointCoordinates",
+                  type: "array",
+                  items: {
+                    $id: "Position",
+                    anyOf: [
+                      {
+                        $id: "Position2D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 2,
+                        maxItems: 2,
+                      },
+                      {
+                        $id: "Position3D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                          {
+                            $id: "Altitude",
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 3,
+                        maxItems: 3,
+                      },
+                    ],
+                  },
+                },
+              },
+              required: ["type", "coordinates"],
+            },
+            {
+              $id: "LineStringGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "LineString",
+                  type: "string",
+                },
+                coordinates: {
+                  minItems: 2,
+                  $id: "LineStringCoordinates",
+                  type: "array",
+                  items: {
+                    $id: "Position",
+                    anyOf: [
+                      {
+                        $id: "Position2D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 2,
+                        maxItems: 2,
+                      },
+                      {
+                        $id: "Position3D",
+                        type: "array",
+                        items: [
+                          {
+                            $id: "Longitude",
+                            minimum: -180,
+                            maximum: 180,
+                            type: "number",
+                          },
+                          {
+                            $id: "Latitude",
+                            minimum: -90,
+                            maximum: 90,
+                            type: "number",
+                          },
+                          {
+                            $id: "Altitude",
+                            type: "number",
+                          },
+                        ],
+                        additionalItems: false,
+                        minItems: 3,
+                        maxItems: 3,
+                      },
+                    ],
+                  },
+                },
+              },
+              required: ["type", "coordinates"],
+            },
+            {
+              $id: "MultiLineStringGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "MultiLineString",
+                  type: "string",
+                },
+                coordinates: {
+                  $id: "MultiLineStringCoordinates",
+                  type: "array",
+                  items: {
+                    minItems: 2,
+                    $id: "LineStringCoordinates",
+                    type: "array",
+                    items: {
+                      $id: "Position",
+                      anyOf: [
+                        {
+                          $id: "Position2D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 2,
+                          maxItems: 2,
+                        },
+                        {
+                          $id: "Position3D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                            {
+                              $id: "Altitude",
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 3,
+                          maxItems: 3,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              required: ["type", "coordinates"],
+            },
+            {
+              $id: "PolygonGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "Polygon",
+                  type: "string",
+                },
+                coordinates: {
+                  $id: "PolygonCoordinates",
+                  type: "array",
+                  items: {
+                    minItems: 4,
+                    $id: "LinearRing",
+                    type: "array",
+                    items: {
+                      $id: "Position",
+                      anyOf: [
+                        {
+                          $id: "Position2D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 2,
+                          maxItems: 2,
+                        },
+                        {
+                          $id: "Position3D",
+                          type: "array",
+                          items: [
+                            {
+                              $id: "Longitude",
+                              minimum: -180,
+                              maximum: 180,
+                              type: "number",
+                            },
+                            {
+                              $id: "Latitude",
+                              minimum: -90,
+                              maximum: 90,
+                              type: "number",
+                            },
+                            {
+                              $id: "Altitude",
+                              type: "number",
+                            },
+                          ],
+                          additionalItems: false,
+                          minItems: 3,
+                          maxItems: 3,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              required: ["type", "coordinates"],
+            },
+            {
+              $id: "MultiPolygonGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "MultiPolygon",
+                  type: "string",
+                },
+                coordinates: {
+                  $id: "MultiPolygonCoordinates",
+                  type: "array",
+                  items: {
+                    $id: "PolygonCoordinates",
+                    type: "array",
+                    items: {
+                      minItems: 4,
+                      $id: "LinearRing",
+                      type: "array",
+                      items: {
+                        $id: "Position",
+                        anyOf: [
+                          {
+                            $id: "Position2D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 2,
+                            maxItems: 2,
+                          },
+                          {
+                            $id: "Position3D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                              {
+                                $id: "Altitude",
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 3,
+                            maxItems: 3,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+              required: ["type", "coordinates"],
+            },
+            {
+              $id: "GeometryCollectionGeometry",
+              type: "object",
+              properties: {
+                type: {
+                  const: "GeometryCollection",
+                  type: "string",
+                },
+                geometries: {
+                  type: "array",
+                  items: {
+                    anyOf: [
+                      {
+                        $ref: "GeometryCollectionGeometry",
+                      },
+                      {
+                        $id: "PointGeometry",
+                        type: "object",
+                        properties: {
+                          type: {
+                            const: "Point",
+                            type: "string",
+                          },
+                          coordinates: {
+                            $id: "Position",
+                            anyOf: [
+                              {
+                                $id: "Position2D",
+                                type: "array",
+                                items: [
+                                  {
+                                    $id: "Longitude",
+                                    minimum: -180,
+                                    maximum: 180,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Latitude",
+                                    minimum: -90,
+                                    maximum: 90,
+                                    type: "number",
+                                  },
+                                ],
+                                additionalItems: false,
+                                minItems: 2,
+                                maxItems: 2,
+                              },
+                              {
+                                $id: "Position3D",
+                                type: "array",
+                                items: [
+                                  {
+                                    $id: "Longitude",
+                                    minimum: -180,
+                                    maximum: 180,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Latitude",
+                                    minimum: -90,
+                                    maximum: 90,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Altitude",
+                                    type: "number",
+                                  },
+                                ],
+                                additionalItems: false,
+                                minItems: 3,
+                                maxItems: 3,
+                              },
+                            ],
+                          },
+                        },
+                        required: ["type", "coordinates"],
+                      },
+                      {
+                        $id: "MultiPointGeometry",
+                        type: "object",
+                        properties: {
+                          type: {
+                            const: "MultiPoint",
+                            type: "string",
+                          },
+                          coordinates: {
+                            $id: "MultiPointCoordinates",
+                            type: "array",
+                            items: {
+                              $id: "Position",
+                              anyOf: [
+                                {
+                                  $id: "Position2D",
+                                  type: "array",
+                                  items: [
+                                    {
+                                      $id: "Longitude",
+                                      minimum: -180,
+                                      maximum: 180,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Latitude",
+                                      minimum: -90,
+                                      maximum: 90,
+                                      type: "number",
+                                    },
+                                  ],
+                                  additionalItems: false,
+                                  minItems: 2,
+                                  maxItems: 2,
+                                },
+                                {
+                                  $id: "Position3D",
+                                  type: "array",
+                                  items: [
+                                    {
+                                      $id: "Longitude",
+                                      minimum: -180,
+                                      maximum: 180,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Latitude",
+                                      minimum: -90,
+                                      maximum: 90,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Altitude",
+                                      type: "number",
+                                    },
+                                  ],
+                                  additionalItems: false,
+                                  minItems: 3,
+                                  maxItems: 3,
+                                },
+                              ],
+                            },
+                          },
+                        },
+                        required: ["type", "coordinates"],
+                      },
+                      {
+                        $id: "LineStringGeometry",
+                        type: "object",
+                        properties: {
+                          type: {
+                            const: "LineString",
+                            type: "string",
+                          },
+                          coordinates: {
+                            minItems: 2,
+                            $id: "LineStringCoordinates",
+                            type: "array",
+                            items: {
+                              $id: "Position",
+                              anyOf: [
+                                {
+                                  $id: "Position2D",
+                                  type: "array",
+                                  items: [
+                                    {
+                                      $id: "Longitude",
+                                      minimum: -180,
+                                      maximum: 180,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Latitude",
+                                      minimum: -90,
+                                      maximum: 90,
+                                      type: "number",
+                                    },
+                                  ],
+                                  additionalItems: false,
+                                  minItems: 2,
+                                  maxItems: 2,
+                                },
+                                {
+                                  $id: "Position3D",
+                                  type: "array",
+                                  items: [
+                                    {
+                                      $id: "Longitude",
+                                      minimum: -180,
+                                      maximum: 180,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Latitude",
+                                      minimum: -90,
+                                      maximum: 90,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Altitude",
+                                      type: "number",
+                                    },
+                                  ],
+                                  additionalItems: false,
+                                  minItems: 3,
+                                  maxItems: 3,
+                                },
+                              ],
+                            },
+                          },
+                        },
+                        required: ["type", "coordinates"],
+                      },
+                      {
+                        $id: "MultiLineStringGeometry",
+                        type: "object",
+                        properties: {
+                          type: {
+                            const: "MultiLineString",
+                            type: "string",
+                          },
+                          coordinates: {
+                            $id: "MultiLineStringCoordinates",
+                            type: "array",
+                            items: {
+                              minItems: 2,
+                              $id: "LineStringCoordinates",
+                              type: "array",
+                              items: {
+                                $id: "Position",
+                                anyOf: [
+                                  {
+                                    $id: "Position2D",
+                                    type: "array",
+                                    items: [
+                                      {
+                                        $id: "Longitude",
+                                        minimum: -180,
+                                        maximum: 180,
+                                        type: "number",
+                                      },
+                                      {
+                                        $id: "Latitude",
+                                        minimum: -90,
+                                        maximum: 90,
+                                        type: "number",
+                                      },
+                                    ],
+                                    additionalItems: false,
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                  {
+                                    $id: "Position3D",
+                                    type: "array",
+                                    items: [
+                                      {
+                                        $id: "Longitude",
+                                        minimum: -180,
+                                        maximum: 180,
+                                        type: "number",
+                                      },
+                                      {
+                                        $id: "Latitude",
+                                        minimum: -90,
+                                        maximum: 90,
+                                        type: "number",
+                                      },
+                                      {
+                                        $id: "Altitude",
+                                        type: "number",
+                                      },
+                                    ],
+                                    additionalItems: false,
+                                    minItems: 3,
+                                    maxItems: 3,
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                        required: ["type", "coordinates"],
+                      },
+                      {
+                        $id: "PolygonGeometry",
+                        type: "object",
+                        properties: {
+                          type: {
+                            const: "Polygon",
+                            type: "string",
+                          },
+                          coordinates: {
+                            $id: "PolygonCoordinates",
+                            type: "array",
+                            items: {
+                              minItems: 4,
+                              $id: "LinearRing",
+                              type: "array",
+                              items: {
+                                $id: "Position",
+                                anyOf: [
+                                  {
+                                    $id: "Position2D",
+                                    type: "array",
+                                    items: [
+                                      {
+                                        $id: "Longitude",
+                                        minimum: -180,
+                                        maximum: 180,
+                                        type: "number",
+                                      },
+                                      {
+                                        $id: "Latitude",
+                                        minimum: -90,
+                                        maximum: 90,
+                                        type: "number",
+                                      },
+                                    ],
+                                    additionalItems: false,
+                                    minItems: 2,
+                                    maxItems: 2,
+                                  },
+                                  {
+                                    $id: "Position3D",
+                                    type: "array",
+                                    items: [
+                                      {
+                                        $id: "Longitude",
+                                        minimum: -180,
+                                        maximum: 180,
+                                        type: "number",
+                                      },
+                                      {
+                                        $id: "Latitude",
+                                        minimum: -90,
+                                        maximum: 90,
+                                        type: "number",
+                                      },
+                                      {
+                                        $id: "Altitude",
+                                        type: "number",
+                                      },
+                                    ],
+                                    additionalItems: false,
+                                    minItems: 3,
+                                    maxItems: 3,
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                        required: ["type", "coordinates"],
+                      },
+                      {
+                        $id: "MultiPolygonGeometry",
+                        type: "object",
+                        properties: {
+                          type: {
+                            const: "MultiPolygon",
+                            type: "string",
+                          },
+                          coordinates: {
+                            $id: "MultiPolygonCoordinates",
+                            type: "array",
+                            items: {
+                              $id: "PolygonCoordinates",
+                              type: "array",
+                              items: {
+                                minItems: 4,
+                                $id: "LinearRing",
+                                type: "array",
+                                items: {
+                                  $id: "Position",
+                                  anyOf: [
+                                    {
+                                      $id: "Position2D",
+                                      type: "array",
+                                      items: [
+                                        {
+                                          $id: "Longitude",
+                                          minimum: -180,
+                                          maximum: 180,
+                                          type: "number",
+                                        },
+                                        {
+                                          $id: "Latitude",
+                                          minimum: -90,
+                                          maximum: 90,
+                                          type: "number",
+                                        },
+                                      ],
+                                      additionalItems: false,
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    {
+                                      $id: "Position3D",
+                                      type: "array",
+                                      items: [
+                                        {
+                                          $id: "Longitude",
+                                          minimum: -180,
+                                          maximum: 180,
+                                          type: "number",
+                                        },
+                                        {
+                                          $id: "Latitude",
+                                          minimum: -90,
+                                          maximum: 90,
+                                          type: "number",
+                                        },
+                                        {
+                                          $id: "Altitude",
+                                          type: "number",
+                                        },
+                                      ],
+                                      additionalItems: false,
+                                      minItems: 3,
+                                      maxItems: 3,
+                                    },
+                                  ],
+                                },
+                              },
+                            },
+                          },
+                        },
+                        required: ["type", "coordinates"],
+                      },
+                    ],
+                  },
+                },
+              },
+              required: ["type", "geometries"],
+            },
+          ],
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    properties: {
+      anyOf: [
+        {
+          $id: "GeoJSONProperties",
+          type: "object",
+          patternProperties: {
+            "^(.*)$": {},
+          },
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  required: ["type", "geometry", "properties"],
+};
+export const FeatureCollection = {
+  $id: "FeatureCollection",
+  type: "object",
+  properties: {
+    type: {
+      const: "FeatureCollection",
+      type: "string",
+    },
+    features: {
+      type: "array",
+      items: {
+        $id: "Feature",
+        type: "object",
+        properties: {
+          id: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+            ],
+          },
+          type: {
+            const: "Feature",
+            type: "string",
+          },
+          geometry: {
+            anyOf: [
+              {
+                $id: "Geometry",
+                anyOf: [
+                  {
+                    $id: "PointGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "Point",
+                        type: "string",
+                      },
+                      coordinates: {
+                        $id: "Position",
+                        anyOf: [
+                          {
+                            $id: "Position2D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 2,
+                            maxItems: 2,
+                          },
+                          {
+                            $id: "Position3D",
+                            type: "array",
+                            items: [
+                              {
+                                $id: "Longitude",
+                                minimum: -180,
+                                maximum: 180,
+                                type: "number",
+                              },
+                              {
+                                $id: "Latitude",
+                                minimum: -90,
+                                maximum: 90,
+                                type: "number",
+                              },
+                              {
+                                $id: "Altitude",
+                                type: "number",
+                              },
+                            ],
+                            additionalItems: false,
+                            minItems: 3,
+                            maxItems: 3,
+                          },
+                        ],
+                      },
+                    },
+                    required: ["type", "coordinates"],
+                  },
+                  {
+                    $id: "MultiPointGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "MultiPoint",
+                        type: "string",
+                      },
+                      coordinates: {
+                        $id: "MultiPointCoordinates",
+                        type: "array",
+                        items: {
+                          $id: "Position",
+                          anyOf: [
+                            {
+                              $id: "Position2D",
+                              type: "array",
+                              items: [
+                                {
+                                  $id: "Longitude",
+                                  minimum: -180,
+                                  maximum: 180,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Latitude",
+                                  minimum: -90,
+                                  maximum: 90,
+                                  type: "number",
+                                },
+                              ],
+                              additionalItems: false,
+                              minItems: 2,
+                              maxItems: 2,
+                            },
+                            {
+                              $id: "Position3D",
+                              type: "array",
+                              items: [
+                                {
+                                  $id: "Longitude",
+                                  minimum: -180,
+                                  maximum: 180,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Latitude",
+                                  minimum: -90,
+                                  maximum: 90,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Altitude",
+                                  type: "number",
+                                },
+                              ],
+                              additionalItems: false,
+                              minItems: 3,
+                              maxItems: 3,
+                            },
+                          ],
+                        },
+                      },
+                    },
+                    required: ["type", "coordinates"],
+                  },
+                  {
+                    $id: "LineStringGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "LineString",
+                        type: "string",
+                      },
+                      coordinates: {
+                        minItems: 2,
+                        $id: "LineStringCoordinates",
+                        type: "array",
+                        items: {
+                          $id: "Position",
+                          anyOf: [
+                            {
+                              $id: "Position2D",
+                              type: "array",
+                              items: [
+                                {
+                                  $id: "Longitude",
+                                  minimum: -180,
+                                  maximum: 180,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Latitude",
+                                  minimum: -90,
+                                  maximum: 90,
+                                  type: "number",
+                                },
+                              ],
+                              additionalItems: false,
+                              minItems: 2,
+                              maxItems: 2,
+                            },
+                            {
+                              $id: "Position3D",
+                              type: "array",
+                              items: [
+                                {
+                                  $id: "Longitude",
+                                  minimum: -180,
+                                  maximum: 180,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Latitude",
+                                  minimum: -90,
+                                  maximum: 90,
+                                  type: "number",
+                                },
+                                {
+                                  $id: "Altitude",
+                                  type: "number",
+                                },
+                              ],
+                              additionalItems: false,
+                              minItems: 3,
+                              maxItems: 3,
+                            },
+                          ],
+                        },
+                      },
+                    },
+                    required: ["type", "coordinates"],
+                  },
+                  {
+                    $id: "MultiLineStringGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "MultiLineString",
+                        type: "string",
+                      },
+                      coordinates: {
+                        $id: "MultiLineStringCoordinates",
+                        type: "array",
+                        items: {
+                          minItems: 2,
+                          $id: "LineStringCoordinates",
+                          type: "array",
+                          items: {
+                            $id: "Position",
+                            anyOf: [
+                              {
+                                $id: "Position2D",
+                                type: "array",
+                                items: [
+                                  {
+                                    $id: "Longitude",
+                                    minimum: -180,
+                                    maximum: 180,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Latitude",
+                                    minimum: -90,
+                                    maximum: 90,
+                                    type: "number",
+                                  },
+                                ],
+                                additionalItems: false,
+                                minItems: 2,
+                                maxItems: 2,
+                              },
+                              {
+                                $id: "Position3D",
+                                type: "array",
+                                items: [
+                                  {
+                                    $id: "Longitude",
+                                    minimum: -180,
+                                    maximum: 180,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Latitude",
+                                    minimum: -90,
+                                    maximum: 90,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Altitude",
+                                    type: "number",
+                                  },
+                                ],
+                                additionalItems: false,
+                                minItems: 3,
+                                maxItems: 3,
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                    required: ["type", "coordinates"],
+                  },
+                  {
+                    $id: "PolygonGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "Polygon",
+                        type: "string",
+                      },
+                      coordinates: {
+                        $id: "PolygonCoordinates",
+                        type: "array",
+                        items: {
+                          minItems: 4,
+                          $id: "LinearRing",
+                          type: "array",
+                          items: {
+                            $id: "Position",
+                            anyOf: [
+                              {
+                                $id: "Position2D",
+                                type: "array",
+                                items: [
+                                  {
+                                    $id: "Longitude",
+                                    minimum: -180,
+                                    maximum: 180,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Latitude",
+                                    minimum: -90,
+                                    maximum: 90,
+                                    type: "number",
+                                  },
+                                ],
+                                additionalItems: false,
+                                minItems: 2,
+                                maxItems: 2,
+                              },
+                              {
+                                $id: "Position3D",
+                                type: "array",
+                                items: [
+                                  {
+                                    $id: "Longitude",
+                                    minimum: -180,
+                                    maximum: 180,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Latitude",
+                                    minimum: -90,
+                                    maximum: 90,
+                                    type: "number",
+                                  },
+                                  {
+                                    $id: "Altitude",
+                                    type: "number",
+                                  },
+                                ],
+                                additionalItems: false,
+                                minItems: 3,
+                                maxItems: 3,
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                    required: ["type", "coordinates"],
+                  },
+                  {
+                    $id: "MultiPolygonGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "MultiPolygon",
+                        type: "string",
+                      },
+                      coordinates: {
+                        $id: "MultiPolygonCoordinates",
+                        type: "array",
+                        items: {
+                          $id: "PolygonCoordinates",
+                          type: "array",
+                          items: {
+                            minItems: 4,
+                            $id: "LinearRing",
+                            type: "array",
+                            items: {
+                              $id: "Position",
+                              anyOf: [
+                                {
+                                  $id: "Position2D",
+                                  type: "array",
+                                  items: [
+                                    {
+                                      $id: "Longitude",
+                                      minimum: -180,
+                                      maximum: 180,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Latitude",
+                                      minimum: -90,
+                                      maximum: 90,
+                                      type: "number",
+                                    },
+                                  ],
+                                  additionalItems: false,
+                                  minItems: 2,
+                                  maxItems: 2,
+                                },
+                                {
+                                  $id: "Position3D",
+                                  type: "array",
+                                  items: [
+                                    {
+                                      $id: "Longitude",
+                                      minimum: -180,
+                                      maximum: 180,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Latitude",
+                                      minimum: -90,
+                                      maximum: 90,
+                                      type: "number",
+                                    },
+                                    {
+                                      $id: "Altitude",
+                                      type: "number",
+                                    },
+                                  ],
+                                  additionalItems: false,
+                                  minItems: 3,
+                                  maxItems: 3,
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    },
+                    required: ["type", "coordinates"],
+                  },
+                  {
+                    $id: "GeometryCollectionGeometry",
+                    type: "object",
+                    properties: {
+                      type: {
+                        const: "GeometryCollection",
+                        type: "string",
+                      },
+                      geometries: {
+                        type: "array",
+                        items: {
+                          anyOf: [
+                            {
+                              $ref: "GeometryCollectionGeometry",
+                            },
+                            {
+                              $id: "PointGeometry",
+                              type: "object",
+                              properties: {
+                                type: {
+                                  const: "Point",
+                                  type: "string",
+                                },
+                                coordinates: {
+                                  $id: "Position",
+                                  anyOf: [
+                                    {
+                                      $id: "Position2D",
+                                      type: "array",
+                                      items: [
+                                        {
+                                          $id: "Longitude",
+                                          minimum: -180,
+                                          maximum: 180,
+                                          type: "number",
+                                        },
+                                        {
+                                          $id: "Latitude",
+                                          minimum: -90,
+                                          maximum: 90,
+                                          type: "number",
+                                        },
+                                      ],
+                                      additionalItems: false,
+                                      minItems: 2,
+                                      maxItems: 2,
+                                    },
+                                    {
+                                      $id: "Position3D",
+                                      type: "array",
+                                      items: [
+                                        {
+                                          $id: "Longitude",
+                                          minimum: -180,
+                                          maximum: 180,
+                                          type: "number",
+                                        },
+                                        {
+                                          $id: "Latitude",
+                                          minimum: -90,
+                                          maximum: 90,
+                                          type: "number",
+                                        },
+                                        {
+                                          $id: "Altitude",
+                                          type: "number",
+                                        },
+                                      ],
+                                      additionalItems: false,
+                                      minItems: 3,
+                                      maxItems: 3,
+                                    },
+                                  ],
+                                },
+                              },
+                              required: ["type", "coordinates"],
+                            },
+                            {
+                              $id: "MultiPointGeometry",
+                              type: "object",
+                              properties: {
+                                type: {
+                                  const: "MultiPoint",
+                                  type: "string",
+                                },
+                                coordinates: {
+                                  $id: "MultiPointCoordinates",
+                                  type: "array",
+                                  items: {
+                                    $id: "Position",
+                                    anyOf: [
+                                      {
+                                        $id: "Position2D",
+                                        type: "array",
+                                        items: [
+                                          {
+                                            $id: "Longitude",
+                                            minimum: -180,
+                                            maximum: 180,
+                                            type: "number",
+                                          },
+                                          {
+                                            $id: "Latitude",
+                                            minimum: -90,
+                                            maximum: 90,
+                                            type: "number",
+                                          },
+                                        ],
+                                        additionalItems: false,
+                                        minItems: 2,
+                                        maxItems: 2,
+                                      },
+                                      {
+                                        $id: "Position3D",
+                                        type: "array",
+                                        items: [
+                                          {
+                                            $id: "Longitude",
+                                            minimum: -180,
+                                            maximum: 180,
+                                            type: "number",
+                                          },
+                                          {
+                                            $id: "Latitude",
+                                            minimum: -90,
+                                            maximum: 90,
+                                            type: "number",
+                                          },
+                                          {
+                                            $id: "Altitude",
+                                            type: "number",
+                                          },
+                                        ],
+                                        additionalItems: false,
+                                        minItems: 3,
+                                        maxItems: 3,
+                                      },
+                                    ],
+                                  },
+                                },
+                              },
+                              required: ["type", "coordinates"],
+                            },
+                            {
+                              $id: "LineStringGeometry",
+                              type: "object",
+                              properties: {
+                                type: {
+                                  const: "LineString",
+                                  type: "string",
+                                },
+                                coordinates: {
+                                  minItems: 2,
+                                  $id: "LineStringCoordinates",
+                                  type: "array",
+                                  items: {
+                                    $id: "Position",
+                                    anyOf: [
+                                      {
+                                        $id: "Position2D",
+                                        type: "array",
+                                        items: [
+                                          {
+                                            $id: "Longitude",
+                                            minimum: -180,
+                                            maximum: 180,
+                                            type: "number",
+                                          },
+                                          {
+                                            $id: "Latitude",
+                                            minimum: -90,
+                                            maximum: 90,
+                                            type: "number",
+                                          },
+                                        ],
+                                        additionalItems: false,
+                                        minItems: 2,
+                                        maxItems: 2,
+                                      },
+                                      {
+                                        $id: "Position3D",
+                                        type: "array",
+                                        items: [
+                                          {
+                                            $id: "Longitude",
+                                            minimum: -180,
+                                            maximum: 180,
+                                            type: "number",
+                                          },
+                                          {
+                                            $id: "Latitude",
+                                            minimum: -90,
+                                            maximum: 90,
+                                            type: "number",
+                                          },
+                                          {
+                                            $id: "Altitude",
+                                            type: "number",
+                                          },
+                                        ],
+                                        additionalItems: false,
+                                        minItems: 3,
+                                        maxItems: 3,
+                                      },
+                                    ],
+                                  },
+                                },
+                              },
+                              required: ["type", "coordinates"],
+                            },
+                            {
+                              $id: "MultiLineStringGeometry",
+                              type: "object",
+                              properties: {
+                                type: {
+                                  const: "MultiLineString",
+                                  type: "string",
+                                },
+                                coordinates: {
+                                  $id: "MultiLineStringCoordinates",
+                                  type: "array",
+                                  items: {
+                                    minItems: 2,
+                                    $id: "LineStringCoordinates",
+                                    type: "array",
+                                    items: {
+                                      $id: "Position",
+                                      anyOf: [
+                                        {
+                                          $id: "Position2D",
+                                          type: "array",
+                                          items: [
+                                            {
+                                              $id: "Longitude",
+                                              minimum: -180,
+                                              maximum: 180,
+                                              type: "number",
+                                            },
+                                            {
+                                              $id: "Latitude",
+                                              minimum: -90,
+                                              maximum: 90,
+                                              type: "number",
+                                            },
+                                          ],
+                                          additionalItems: false,
+                                          minItems: 2,
+                                          maxItems: 2,
+                                        },
+                                        {
+                                          $id: "Position3D",
+                                          type: "array",
+                                          items: [
+                                            {
+                                              $id: "Longitude",
+                                              minimum: -180,
+                                              maximum: 180,
+                                              type: "number",
+                                            },
+                                            {
+                                              $id: "Latitude",
+                                              minimum: -90,
+                                              maximum: 90,
+                                              type: "number",
+                                            },
+                                            {
+                                              $id: "Altitude",
+                                              type: "number",
+                                            },
+                                          ],
+                                          additionalItems: false,
+                                          minItems: 3,
+                                          maxItems: 3,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                },
+                              },
+                              required: ["type", "coordinates"],
+                            },
+                            {
+                              $id: "PolygonGeometry",
+                              type: "object",
+                              properties: {
+                                type: {
+                                  const: "Polygon",
+                                  type: "string",
+                                },
+                                coordinates: {
+                                  $id: "PolygonCoordinates",
+                                  type: "array",
+                                  items: {
+                                    minItems: 4,
+                                    $id: "LinearRing",
+                                    type: "array",
+                                    items: {
+                                      $id: "Position",
+                                      anyOf: [
+                                        {
+                                          $id: "Position2D",
+                                          type: "array",
+                                          items: [
+                                            {
+                                              $id: "Longitude",
+                                              minimum: -180,
+                                              maximum: 180,
+                                              type: "number",
+                                            },
+                                            {
+                                              $id: "Latitude",
+                                              minimum: -90,
+                                              maximum: 90,
+                                              type: "number",
+                                            },
+                                          ],
+                                          additionalItems: false,
+                                          minItems: 2,
+                                          maxItems: 2,
+                                        },
+                                        {
+                                          $id: "Position3D",
+                                          type: "array",
+                                          items: [
+                                            {
+                                              $id: "Longitude",
+                                              minimum: -180,
+                                              maximum: 180,
+                                              type: "number",
+                                            },
+                                            {
+                                              $id: "Latitude",
+                                              minimum: -90,
+                                              maximum: 90,
+                                              type: "number",
+                                            },
+                                            {
+                                              $id: "Altitude",
+                                              type: "number",
+                                            },
+                                          ],
+                                          additionalItems: false,
+                                          minItems: 3,
+                                          maxItems: 3,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                },
+                              },
+                              required: ["type", "coordinates"],
+                            },
+                            {
+                              $id: "MultiPolygonGeometry",
+                              type: "object",
+                              properties: {
+                                type: {
+                                  const: "MultiPolygon",
+                                  type: "string",
+                                },
+                                coordinates: {
+                                  $id: "MultiPolygonCoordinates",
+                                  type: "array",
+                                  items: {
+                                    $id: "PolygonCoordinates",
+                                    type: "array",
+                                    items: {
+                                      minItems: 4,
+                                      $id: "LinearRing",
+                                      type: "array",
+                                      items: {
+                                        $id: "Position",
+                                        anyOf: [
+                                          {
+                                            $id: "Position2D",
+                                            type: "array",
+                                            items: [
+                                              {
+                                                $id: "Longitude",
+                                                minimum: -180,
+                                                maximum: 180,
+                                                type: "number",
+                                              },
+                                              {
+                                                $id: "Latitude",
+                                                minimum: -90,
+                                                maximum: 90,
+                                                type: "number",
+                                              },
+                                            ],
+                                            additionalItems: false,
+                                            minItems: 2,
+                                            maxItems: 2,
+                                          },
+                                          {
+                                            $id: "Position3D",
+                                            type: "array",
+                                            items: [
+                                              {
+                                                $id: "Longitude",
+                                                minimum: -180,
+                                                maximum: 180,
+                                                type: "number",
+                                              },
+                                              {
+                                                $id: "Latitude",
+                                                minimum: -90,
+                                                maximum: 90,
+                                                type: "number",
+                                              },
+                                              {
+                                                $id: "Altitude",
+                                                type: "number",
+                                              },
+                                            ],
+                                            additionalItems: false,
+                                            minItems: 3,
+                                            maxItems: 3,
+                                          },
+                                        ],
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                              required: ["type", "coordinates"],
+                            },
+                          ],
+                        },
+                      },
+                    },
+                    required: ["type", "geometries"],
+                  },
+                ],
+              },
+              {
+                type: "null",
+              },
+            ],
+          },
+          properties: {
+            anyOf: [
+              {
+                $id: "GeoJSONProperties",
+                type: "object",
+                patternProperties: {
+                  "^(.*)$": {},
+                },
+              },
+              {
+                type: "null",
+              },
+            ],
+          },
+        },
+        required: ["type", "geometry", "properties"],
+      },
+    },
+  },
+  required: ["type", "features"],
+};

--- a/packages/json-schema/tsconfig.cjs.json
+++ b/packages/json-schema/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ESNext",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/json-schema/tsconfig.esm.json
+++ b/packages/json-schema/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ESNext",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   packages/benchmarks:
     dependencies:
+      '@rfc7946/json-schema':
+        specifier: workspace:*
+        version: link:../json-schema
       '@rfc7946/typebox':
         specifier: workspace:*
         version: link:../typebox
@@ -65,6 +68,8 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.32.31
         version: 0.32.31
+
+  packages/json-schema: {}
 
   packages/typebox:
     dependencies:


### PR DESCRIPTION
Fails with:
```
Error: reference "Longitude" resolves to more than one schema
    at ambiguos (./rfc7946/node_modules/.pnpm/ajv@8.14.0/node_modules/ajv/lib/compile/resolve.ts:147:12)
    at Ajv.addRef (./rfc7946/node_modules/.pnpm/ajv@8.14.0/node_modules/ajv/lib/compile/resolve.ts:115:38)
    at <anonymous> (./rfc7946/node_modules/.pnpm/ajv@8.14.0/node_modules/ajv/lib/compile/resolve.ts:106:64)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:69:5)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:75:13)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:75:13)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:80:13)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:75:13)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:75:13)
    at _traverse (./rfc7946/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse/index.js:80:13)
```